### PR TITLE
Update pypubsub to 0.7.4 from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.7.4
+- Added support for TLS (HTTPS) on a separate port.
+
 # 0.7.3
 - Added support for reloading the ACL configuration with SIGUSR2 (#2).
 - Added support for resuming a stream with a sequence cursor.

--- a/pypubsub.py
+++ b/pypubsub.py
@@ -90,7 +90,10 @@ class Configuration:
         server_payload_limit = int(yml['server'].get('max_payload_size', PUBSUB_DEFAULT_MAX_PAYLOAD_SIZE))
         tls_port = 0
         tls_ctx = None
-        if 'tls' in yml['server']:
+        # TLS support, if configured
+        if 'tls' in yml['server'] and isinstance(yml['server']['tls'], dict):
+            for required_element in ("port", "cert", "key", ):
+                assert yml['server']['tls'].get(required_element), f"TLS: configuration option '{required_element}' is missing or invalid, cannot enable TLS!"
             import ssl
             tls_port = int(yml['server']['tls']['port'])
             # Create TLS context and load cert+key

--- a/pypubsub.yaml
+++ b/pypubsub.yaml
@@ -6,6 +6,12 @@ server:
   backlog:
     size:           0   # Max number of payloads to keep in backlog cache (set to 0 to disable)
     max_age:      48h   # Maximum age of a backlog item before culling it (set to 0 to never prune on age)
+  # Uncomment the parts below for TLS support
+  #tls:
+  #  port: 2070
+  #  cert: /path/to/domain.crt
+  #  key: /path/to/domain.key
+  #  chain: /path/to/domain.chain
 #    storage: backlog.json  # File-storage for backlog between restarts. Comment out to disable.
 # Client settings
 clients:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp>=3.6.0
 asyncio>=3.4.3
 netaddr>=0.7.19
 python-ldap>=3.0.0
-PyYAML~=5.4.1
+PyYAML
 aiobotocore~=1.0.7
 botocore~=1.15.32
 aiofile~=3.8.5


### PR DESCRIPTION
Adds TLS support on a separate port. Both ports are connected to the same topic stream.